### PR TITLE
fix scalar NULLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ global.exports('scalar', (query, parameters, callback) => {
   [sql, params, cb] = sanitizeInput(sql, params, cb);
 
   execute(sql, params).then((result) => {
-    safeInvoke(cb, Object.values(result[0])[0]);
+    safeInvoke(cb, Object.values(result[0] || [])[0]);
   });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ global.exports('scalar', (query, parameters, callback) => {
   [sql, params, cb] = sanitizeInput(sql, params, cb);
 
   execute(sql, params).then((result) => {
-    safeInvoke(cb, Object.values(result[0] || [])[0]);
+    safeInvoke(cb, Object.values(result[0] || {})[0]);
   });
 });
 


### PR DESCRIPTION
Prevent error when scalar returns NULL.

```
Error: (node:3416) UnhandledPromiseRejectionWarning: TypeError: Cannot convert undefined or null to object
    at Function.values (<anonymous>)
    at execute.then.result (ghmattimysql.js:390:1800)
    at process._tickCallback (internal/process/next_tick.js:188:7)
```