### PR TITLE
Fix error: 'First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.'

### DIFF
--- a/packages/ghmattimysql/src/server/utility/getConfig.ts
+++ b/packages/ghmattimysql/src/server/utility/getConfig.ts
@@ -12,11 +12,14 @@ function getConfigFromConnectionString() {
       .replace(/(?:user\s?(?:id|name)?|uid)=/gi, 'user=')
       .replace(/(?:password|pwd)=/gi, 'password=')
       .replace(/(?:database|initial\scatalog)=/gi, 'database=');
-    connectionStr.split(';').forEach((el) => {
-      const equal = el.indexOf('=');
-      const key = (equal > -1) ? el.substr(0, equal) : el;
-      const value = (equal > -1) ? el.substr(equal + 1) : '';
-      cfg[key.trim()] = (Number.isNaN(Number(value))) ? value : Number(value);
+    connectionStr.split(';').forEach(c => {
+      const equal = c.indexOf('=');
+      const key = (equal > -1) ? c.substr(0, equal) : c;
+      const value = (equal > -1) ? c.substr(equal + 1) : '';
+      cfg = {
+        ...cfg,
+        [key]: key.includes("port") ? Number(value) : value
+      };
     });
   } else if (/mysql:\/\//gi.test(connectionString)) {
     cfg = parseUrl(connectionString);


### PR DESCRIPTION
Error:
![unknown](https://user-images.githubusercontent.com/8194839/103111572-cef71b80-4624-11eb-9695-ae0b6bc5d3a0.png)

Because of this `(Number.isNaN(Number(value))) ? value : Number(value);` if the password of your database includes only numbers then the value will be of type number causing that error to occur by line no. 2033 `var stage1 = sha1((Buffer.from(password, 'utf8')).toString('binary'));` of mysql-async.js

The only reason I can believe the variable is wanted to be converted to type numero is because of the port, so I made a small fix for it.