### PR TITLE
Wrap queries with setImmediate

### DIFF
--- a/packages/ghmattimysql/src/server/mysql/index.ts
+++ b/packages/ghmattimysql/src/server/mysql/index.ts
@@ -53,7 +53,10 @@ class MySQL {
       db.query(sql, (error, result) => {
         this.profiler.profile(process.hrtime(start), this.formatQuery(sql), invokingResource);
         if (error) reject(error);
-        resolve(result);
+        
+        setImmediate(async () => {
+          resolve(result);
+        });
       });
     }).catch((error) => {
       if (connection) {


### PR DESCRIPTION
Hello,

this pull request could fix a problem with slow queries. I myself still have problems with slow queries despite very well adapted scripts.

with setImmediate() the result of the mysql query is called in the next event loop.
I haven't tested the whole thing yet, but several people have heard that many mysql slow query problems are fixed there.